### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*,bugprone-*'
+WarningsAsErrors: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI Build and Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IDF_TARGET: esp32
+
+jobs:
+  build:
+    name: Build \u279c ${{ matrix.idf_version }} \u00b7 ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_version: [ release-v5.5 ]
+        build_type: [ Release, Debug ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Format Check
+        run: clang-format --dry-run --Werror $(git ls-files '*.c' '*.cpp' '*.h' '*.hpp')
+
+      - name: Prepare ESP-IDF project
+        run: |
+          rm -rf ci_project
+          mkdir -p ci_project/main
+          cat <<'EOF' > ci_project/CMakeLists.txt
+          cmake_minimum_required(VERSION 3.16)
+          include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+          project(as5047u_ci)
+          EOF
+          if [ -f examples/es32_basic_interface/main.cpp ]; then
+            cp examples/es32_basic_interface/main.cpp ci_project/main/main.cpp
+          elif [ -f examples/esp32_basic_interface/main.cpp ]; then
+            cp examples/esp32_basic_interface/main.cpp ci_project/main/main.cpp
+          else
+            cat <<'EOM' > ci_project/main/main.cpp
+            #include "AS5047U.hpp"
+            extern "C" void app_main() { (void)sizeof(AS5047U); }
+            EOM
+          fi
+          cat <<'EOF' > ci_project/main/CMakeLists.txt
+          idf_component_register(
+              SRCS "main.cpp" "../../src/AS5047U.cpp"
+              INCLUDE_DIRS "." "../../include" "../../src"
+          )
+          EOF
+
+      - name: Build and Validate
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ matrix.idf_version }}
+          target: ${{ env.IDF_TARGET }}
+          path: .
+          command: |
+            idf.py -B ci_project/build -C ci_project -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -B ci_project/build -C ci_project size
+            idf.py -B ci_project/build -C ci_project size-components
+            idf.py -B ci_project/build -C ci_project size-files
+            idf.py -B ci_project/build -C ci_project size-json
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 7
+          path: |
+            ci_project/build/*.bin
+            ci_project/build/*.elf
+            ci_project/build/*.map
+            ci_project/build/size*.txt
+            ci_project/build/size*.json
+
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Run cppcheck
+        uses: deep5050/cppcheck-action@v3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: all
+          inconclusive: true
+          std: c++20
+
+      - name: Run clang-tidy
+        uses: ZedThree/clang-tidy-review@v0.21.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .clang-tidy
+
+  workflow-lint:
+    name: Lint Workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.6.25

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Hardware Agnostic AS5047U library - as used in the HardFOC-V1 controller
 # AS5047U – C++ Driver Library
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![CI Build](https://github.com/N3b3x/HF-AS5047U/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/N3b3x/HF-AS5047U/actions/workflows/ci.yml)
 
 
 ## 📦 Overview


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and analyze driver
- include clang-format and clang-tidy configuration files
- add CI badge to README
- inline build commands in workflow and remove helper script

## Testing
- `make clean && make test`
- `./actionlint -color` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e473949008328acf75203b077e80b