### PR TITLE
Add ESP-IDF example and CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,117 +1,103 @@
-name: CI Build and Analysis
+name: CI \u2022 Build \u00b7 Size \u00b7 Static Analyse
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  IDF_TARGET: esp32
+  IDF_TARGET: esp32c6
+  BUILD_PATH: ci_project
+  ESP_IDF_VERSIONS: '["release-v5.5"]'
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
     name: Build \u279c ${{ matrix.idf_version }} \u00b7 ${{ matrix.build_type }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        idf_version: [ release-v5.5 ]
-        build_type: [ Release, Debug ]
+        idf_version: [release-v5.5]
+        build_type: [Release, Debug]
+
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install clang-format
+      - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
-      - name: Format Check
-        run: clang-format --dry-run --Werror $(git ls-files '*.c' '*.cpp' '*.h' '*.hpp')
+      - name: Format check
+        run: clang-format --dry-run --Werror src/*.hpp src/*.cpp examples/esp32/main/*.cpp
 
-      - name: Prepare ESP-IDF project
-        run: |
-          rm -rf ci_project
-          mkdir -p ci_project/main
-          cat <<'EOF' > ci_project/CMakeLists.txt
-          cmake_minimum_required(VERSION 3.16)
-          include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-          project(as5047u_ci)
-          EOF
-          if [ -f examples/es32_basic_interface/main.cpp ]; then
-            cp examples/es32_basic_interface/main.cpp ci_project/main/main.cpp
-          elif [ -f examples/esp32_basic_interface/main.cpp ]; then
-            cp examples/esp32_basic_interface/main.cpp ci_project/main/main.cpp
-          else
-            cat <<'EOM' > ci_project/main/main.cpp
-            #include "AS5047U.hpp"
-            extern "C" void app_main() { (void)sizeof(AS5047U); }
-            EOM
-          fi
-          cat <<'EOF' > ci_project/main/CMakeLists.txt
-          idf_component_register(
-              SRCS "main.cpp" "../../src/AS5047U.cpp"
-              INCLUDE_DIRS "." "../../include" "../../src"
-          )
-          EOF
-
-      - name: Build and Validate
+      - name: ESP-IDF build
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: ${{ matrix.idf_version }}
           target: ${{ env.IDF_TARGET }}
           path: .
           command: |
-            idf.py -B ci_project/build -C ci_project -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} build
-            idf.py -B ci_project/build -C ci_project size
-            idf.py -B ci_project/build -C ci_project size-components
-            idf.py -B ci_project/build -C ci_project size-files
-            idf.py -B ci_project/build -C ci_project size-json
+            idf.py create-project ${{ env.BUILD_PATH }}
+            cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
+            sed -i "s|../../components|../components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
+            rm -rf ${{ env.BUILD_PATH }}/main
+            cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
+            idf.py -C ${{ env.BUILD_PATH }} size --format json > ${{ env.BUILD_PATH }}/build/size.json
 
       - name: Upload artifacts
-        if: always()
         uses: actions/upload-artifact@v4
+        if: always()
         with:
-          name: firmware-${{ matrix.idf_version }}-${{ matrix.build_type }}
-          retention-days: 7
+          name: fw-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 14
           path: |
-            ci_project/build/*.bin
-            ci_project/build/*.elf
-            ci_project/build/*.map
-            ci_project/build/size*.txt
-            ci_project/build/size*.json
+            ${{ env.BUILD_PATH }}/build/*.bin
+            ${{ env.BUILD_PATH }}/build/*.elf
+            ${{ env.BUILD_PATH }}/build/*.map
+            ${{ env.BUILD_PATH }}/build/size.*
 
   static-analysis:
-    name: Static Analysis
+    if: github.event_name == 'pull_request'
+    name: Static analyse (cppcheck + clang-tidy)
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Run cppcheck
-        uses: deep5050/cppcheck-action@v3.0
+      - uses: deep5050/cppcheck-action@v3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           enable: all
           inconclusive: true
-          std: c++20
+          std: c99
+          include: main
 
-      - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.21.0
+      - uses: ZedThree/clang-tidy-review@v0.21.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config_file: .clang-tidy
 
   workflow-lint:
-    name: Lint Workflow
+    name: actionlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/components/hf_as5047u/CMakeLists.txt
+++ b/components/hf_as5047u/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "../../src/AS5047U.cpp"
+    INCLUDE_DIRS "../../src" "../../include"
+)

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.16)
+set(EXTRA_COMPONENT_DIRS "../../components")
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(as5047u_example)

--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS "."
+    REQUIRES hf_as5047u
+)

--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -1,0 +1,19 @@
+#include "AS5047U.hpp"
+#include <cstdio>
+
+class DummyBus : public AS5047U::spiBus {
+  public:
+    void transfer(const uint8_t *tx, uint8_t *rx, size_t len) override {
+        (void)tx;
+        for (size_t i = 0; i < len; ++i) {
+            if (rx)
+                rx[i] = 0;
+        }
+    }
+};
+
+extern "C" void app_main(void) {
+    DummyBus bus;
+    AS5047U sensor(bus);
+    printf("AGC: %u\n", sensor.getAGC());
+}

--- a/src/AS5047U.cpp
+++ b/src/AS5047U.cpp
@@ -2,9 +2,7 @@
 #include <iomanip> // for std::hex and formatting
 
 // Inline function definitions
-inline void AS5047U::setFrameFormat(FrameFormat format) noexcept {
-    frameFormat = format;
-}
+inline void AS5047U::setFrameFormat(FrameFormat format) noexcept { frameFormat = format; }
 
 // Constructor implementation
 AS5047U::AS5047U(AS5047U::spiBus &bus, FrameFormat frameFormat) noexcept
@@ -26,34 +24,40 @@ AS5047U::AS5047U(AS5047U::spiBus &bus, FrameFormat frameFormat) noexcept
 
 uint16_t AS5047U::getAngle(uint8_t retries) const {
     uint16_t val = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t i = 0; i <= retries; ++i) {
         val = readReg<AS5047U_REG::ANGLECOM>().bits.ANGLECOM_value;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
     return val;
 }
 
 uint16_t AS5047U::getRawAngle(uint8_t retries) const {
     uint16_t val = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t i = 0; i <= retries; ++i) {
         val = readReg<AS5047U_REG::ANGLEUNC>().bits.ANGLEUNC_value;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
     return val;
 }
 
 int16_t AS5047U::getVelocity(uint8_t retries) const {
     int16_t val = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t i = 0; i <= retries; ++i) {
         auto v = readReg<AS5047U_REG::VEL>().bits.VEL_value;
         val = static_cast<int16_t>((static_cast<int16_t>(v << 2)) >> 2);
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
     return val;
 }
@@ -72,22 +76,26 @@ double AS5047U::getVelocityRPM(uint8_t retries) const {
 
 uint8_t AS5047U::getAGC(uint8_t retries) const {
     uint8_t val = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t i = 0; i <= retries; ++i) {
         val = readReg<AS5047U_REG::AGC>().bits.AGC_value;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
     return val;
 }
 
 uint16_t AS5047U::getMagnitude(uint8_t retries) const {
     uint16_t val = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t i = 0; i <= retries; ++i) {
         val = readReg<AS5047U_REG::MAG>().bits.MAG_value;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
     return val;
 }
@@ -96,7 +104,8 @@ uint16_t AS5047U::getErrorFlags(uint8_t retries) const {
     uint16_t val = 0;
     for (uint8_t i = 0; i <= retries; ++i) {
         val = readReg<AS5047U_REG::ERRFL>().value;
-        if (val == 0) break;
+        if (val == 0)
+            break;
     }
     return val;
 }
@@ -104,28 +113,33 @@ uint16_t AS5047U::getErrorFlags(uint8_t retries) const {
 uint16_t AS5047U::getZeroPosition(uint8_t retries) const {
     uint8_t m = 0;
     uint8_t l = 0;
-    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
-    
+    constexpr uint16_t retryMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                                   static_cast<uint16_t>(AS5047U_Error::FramingError);
+
     // First read ZPOSM with retries
     for (uint8_t i = 0; i <= retries; ++i) {
         m = readReg<AS5047U_REG::ZPOSM>().bits.ZPOSM_bits;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
-    
+
     // Then read ZPOSL with retries
     for (uint8_t i = 0; i <= retries; ++i) {
         l = readReg<AS5047U_REG::ZPOSL>().bits.ZPOSL_bits;
         auto err = getStickyErrorFlags();
-        if (!(static_cast<uint16_t>(err) & retryMask)) break;
+        if (!(static_cast<uint16_t>(err) & retryMask))
+            break;
     }
-    
+
     return static_cast<uint16_t>((m << 6) | l);
 }
 
 bool AS5047U::setZeroPosition(uint16_t angleLSB, uint8_t retries) {
-    AS5047U_REG::ZPOSM m{}; m.bits.ZPOSM_bits = (angleLSB >> 6) & 0xFF;
-    AS5047U_REG::ZPOSL l{}; l.bits.ZPOSL_bits = angleLSB & 0x3F;
+    AS5047U_REG::ZPOSM m{};
+    m.bits.ZPOSM_bits = (angleLSB >> 6) & 0xFF;
+    AS5047U_REG::ZPOSL l{};
+    l.bits.ZPOSL_bits = angleLSB & 0x3F;
     return writeReg(m, retries) && writeReg(l, retries);
 }
 
@@ -162,15 +176,18 @@ bool AS5047U::setIndexPulseLength(uint8_t lsbLen, uint8_t retries) {
 //
 bool AS5047U::configureInterface(bool abi, bool uvw, bool pwm, uint8_t retries) {
     auto dis = readReg<AS5047U_REG::DISABLE>();
-    auto s2  = readReg<AS5047U_REG::SETTINGS2>();
+    auto s2 = readReg<AS5047U_REG::SETTINGS2>();
     dis.bits.ABI_off = abi ? 0 : 1;
     dis.bits.UVW_off = uvw ? 0 : 1;
     if (abi && !uvw) {
-        s2.bits.UVW_ABI = 0; s2.bits.PWMon = pwm;
+        s2.bits.UVW_ABI = 0;
+        s2.bits.PWMon = pwm;
     } else if (!abi && uvw) {
-        s2.bits.UVW_ABI = 1; s2.bits.PWMon = pwm;
+        s2.bits.UVW_ABI = 1;
+        s2.bits.PWMon = pwm;
     } else {
-        s2.bits.UVW_ABI = 0; s2.bits.PWMon = pwm;
+        s2.bits.UVW_ABI = 0;
+        s2.bits.PWMon = pwm;
     }
     return writeReg(dis, retries) && writeReg(s2, retries);
 }
@@ -188,9 +205,11 @@ bool AS5047U::setAdaptiveFilter(bool enable, uint8_t retries) {
 }
 
 bool AS5047U::setFilterParameters(uint8_t k_min, uint8_t k_max, uint8_t retries) {
-    k_min = std::min(k_min, uint8_t(7)); k_max = std::min(k_max, uint8_t(7));
+    k_min = std::min(k_min, uint8_t(7));
+    k_max = std::min(k_max, uint8_t(7));
     auto s1 = readReg<AS5047U_REG::SETTINGS1>();
-    s1.bits.K_min = k_min; s1.bits.K_max = k_max;
+    s1.bits.K_min = k_min;
+    s1.bits.K_max = k_max;
     return writeReg(s1, retries);
 }
 
@@ -206,16 +225,16 @@ bool AS5047U::programOTP() {
     if (frameFormat == FrameFormat::SPI_16) {
         frameFormat = FrameFormat::SPI_24;
     }
-    
+
     // Set current angle as zero position
     setZeroPosition(getAngle());
-    
+
     // Backup the volatile shadow registers that will be committed to OTP
     uint16_t volatileShadow[5];
     for (uint16_t a = 0x0016; a <= 0x001A; ++a) {
-        volatileShadow[a-0x0016] = readRegister(a);
+        volatileShadow[a - 0x0016] = readRegister(a);
     }
-    
+
     // Enable ECC and compute needed checksum
     auto ecc = readReg<AS5047U_REG::ECC>();
     ecc.bits.ECC_en = 1;
@@ -223,48 +242,48 @@ bool AS5047U::programOTP() {
     auto key = readReg<AS5047U_REG::ECC_Checksum>().bits.ECC_s;
     ecc.bits.ECC_chsum = key;
     writeReg(ecc);
-    
+
     // Verify shadow registers are still correct
     for (uint16_t a = 0x0016; a <= 0x001A; ++a) {
-        if (readRegister(a) != volatileShadow[a-0x0016]) { 
-            frameFormat = backup; 
-            return false; 
+        if (readRegister(a) != volatileShadow[a - 0x0016]) {
+            frameFormat = backup;
+            return false;
         }
     }
-    
+
     // Begin OTP programming sequence
-    AS5047U_REG::PROG p{};  
-    p.bits.PROGEN = 1;  
+    AS5047U_REG::PROG p{};
+    p.bits.PROGEN = 1;
     writeReg(p);
-    p.bits.PROGOTP = 1;     
+    p.bits.PROGOTP = 1;
     writeReg(p);
-    
+
     // Wait for programming to complete (timeout after ~15000 cycles)
     for (uint16_t i = 0; i < 15000; ++i) {
-        if (readRegister(AS5047U_REG::PROG::ADDRESS) == 0x0001) { 
-            frameFormat = backup; 
-            
+        if (readRegister(AS5047U_REG::PROG::ADDRESS) == 0x0001) {
+            frameFormat = backup;
+
             // Guard-band verification: enable PROGVER and refresh OTPREF
-            p.bits.PROGVER = 1; 
+            p.bits.PROGVER = 1;
             writeReg(p);
-            
+
             // Toggle OTPREF to reload from OTP
-            p.bits.OTPREF = 1; 
+            p.bits.OTPREF = 1;
             writeReg(p);
-            p.bits.OTPREF = 0; 
+            p.bits.OTPREF = 0;
             writeReg(p);
-            
+
             // Verify shadow registers match OTP
             for (uint16_t a = 0x0016; a <= 0x001A; ++a) {
-                if (readRegister(a) != volatileShadow[a-0x0016]) { 
-                    frameFormat = backup; 
-                    return false; 
+                if (readRegister(a) != volatileShadow[a - 0x0016]) {
+                    frameFormat = backup;
+                    return false;
                 }
             }
-            return true; 
+            return true;
         }
     }
-    
+
     // Restore original frame format and return failure if timeout
     frameFormat = backup;
     return false;
@@ -272,18 +291,28 @@ bool AS5047U::programOTP() {
 
 void AS5047U::updateStickyErrors(uint16_t errfl) const {
     // Map ERRFL bits (0-10) to sticky error enum
-    if (errfl & (1u << 0))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::AgcWarning);
-    if (errfl & (1u << 1))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::MagHalf);
-    if (errfl & (1u << 2))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::P2ramWarning);
-    if (errfl & (1u << 3))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::P2ramError);
-    if (errfl & (1u << 4))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::FramingError);
-    if (errfl & (1u << 5))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CommandError);
-    if (errfl & (1u << 6))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CrcError);
-    if (errfl & (1u << 7))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::WatchdogError);
-    if (errfl & (1u << 9))  stickyErrors |= static_cast<uint16_t>(AS5047U_Error::OffCompError);
-    if (errfl & (1u << 10)) stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CordicOverflow);
+    if (errfl & (1u << 0))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::AgcWarning);
+    if (errfl & (1u << 1))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::MagHalf);
+    if (errfl & (1u << 2))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::P2ramWarning);
+    if (errfl & (1u << 3))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::P2ramError);
+    if (errfl & (1u << 4))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::FramingError);
+    if (errfl & (1u << 5))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CommandError);
+    if (errfl & (1u << 6))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CrcError);
+    if (errfl & (1u << 7))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::WatchdogError);
+    if (errfl & (1u << 9))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::OffCompError);
+    if (errfl & (1u << 10))
+        stickyErrors |= static_cast<uint16_t>(AS5047U_Error::CordicOverflow);
 }
- 
+
 AS5047U_Error AS5047U::getStickyErrorFlags() const {
     uint16_t val = stickyErrors.exchange(0);
     return static_cast<AS5047U_Error>(val);
@@ -314,9 +343,7 @@ AS5047U_REG::SETTINGS2::AngleOutputSource AS5047U::getAngleOutputSource() const 
     return static_cast<AS5047U_REG::SETTINGS2::AngleOutputSource>(s2.bits.Data_select);
 }
 
-AS5047U_REG::DIA AS5047U::getDiagnostics() const {
-    return readReg<AS5047U_REG::DIA>();
-}
+AS5047U_REG::DIA AS5047U::getDiagnostics() const { return readReg<AS5047U_REG::DIA>(); }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════
 //                           PRIVATE - COMMUNICATION API
@@ -329,49 +356,39 @@ uint16_t AS5047U::rawReadRegister(uint16_t address) const {
         // ---- 16-bit frame without CRC ----
         // Prepare read command (bit14=1 for read)
         uint16_t cmd = static_cast<uint16_t>(0x4000 | (address & 0x3FFF));
-        uint8_t tx[2] = {
-            static_cast<uint8_t>(cmd >> 8),
-            static_cast<uint8_t>(cmd & 0xFF)
-        };
+        uint8_t tx[2] = {static_cast<uint8_t>(cmd >> 8), static_cast<uint8_t>(cmd & 0xFF)};
         uint8_t rx[2];
-        
+
         // Send read command
         spi.transfer(tx, rx, 2);
-        
+
         // Send NOP to receive register data
         uint8_t txNOP[2] = {0x00, 0x00};
         uint8_t rxData[2];
         spi.transfer(txNOP, rxData, 2);
-        
+
         // Process response
         uint16_t raw = (static_cast<uint16_t>(rxData[0]) << 8) | rxData[1];
-        result = raw & 0x3FFF;  // Mask out status flags
-    } 
-    else if (frameFormat == FrameFormat::SPI_24) {
+        result = raw & 0x3FFF; // Mask out status flags
+    } else if (frameFormat == FrameFormat::SPI_24) {
         // ---- 24-bit frame with CRC ----
         // Prepare read command with CRC
         uint16_t crcInput = static_cast<uint16_t>((1 << 14) | (address & 0x3FFF));
         uint8_t crc = computeCRC8(crcInput);
-        uint8_t txCmd[3] = {
-            static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x40),  // bit6=1 for read
-            static_cast<uint8_t>(address & 0xFF),
-            crc
-        };
+        uint8_t txCmd[3] = {static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x40), // bit6=1 for read
+                            static_cast<uint8_t>(address & 0xFF), crc};
         uint8_t rxCmd[3];
         spi.transfer(txCmd, rxCmd, 3);
-        
+
         // Send NOP to receive register data
         uint16_t nopAddr = AS5047U_REG::NOP::ADDRESS;
         uint16_t nopCrcInput = static_cast<uint16_t>((1 << 14) | (nopAddr & 0x3FFF));
         uint8_t crcNOP = computeCRC8(nopCrcInput);
-        uint8_t txNOP[3] = {
-            static_cast<uint8_t>(((nopAddr >> 8) & 0x3F) | 0x40),
-            static_cast<uint8_t>(nopAddr & 0xFF),
-            crcNOP
-        };
+        uint8_t txNOP[3] = {static_cast<uint8_t>(((nopAddr >> 8) & 0x3F) | 0x40),
+                            static_cast<uint8_t>(nopAddr & 0xFF), crcNOP};
         uint8_t rxDataFrame[3];
         spi.transfer(txNOP, rxDataFrame, 3);
-        
+
         // Process response with CRC verification
         uint16_t raw = (static_cast<uint16_t>(rxDataFrame[0]) << 8) | rxDataFrame[1];
         uint8_t crcDevice = rxDataFrame[2];
@@ -380,34 +397,26 @@ uint16_t AS5047U::rawReadRegister(uint16_t address) const {
             // crc error, caller will read ERRFL
         }
         result = raw & 0x3FFF;
-    } 
-    else if (frameFormat == FrameFormat::SPI_32) {
+    } else if (frameFormat == FrameFormat::SPI_32) {
         // ---- 32-bit frame with CRC and pad byte ----
         // Prepare read command with CRC and pad
         uint16_t crcInput = static_cast<uint16_t>((1 << 14) | (address & 0x3FFF));
         uint8_t crc = computeCRC8(crcInput);
-        uint8_t txCmd[4] = {
-            padByte,
-            static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x40),  // bit6=1 for read
-            static_cast<uint8_t>(address & 0xFF),
-            crc
-        };
+        uint8_t txCmd[4] = {padByte,
+                            static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x40), // bit6=1 for read
+                            static_cast<uint8_t>(address & 0xFF), crc};
         uint8_t rxCmd[4];
         spi.transfer(txCmd, rxCmd, 4);
-        
+
         // Send NOP to receive register data
         uint16_t nopAddr = AS5047U_REG::NOP::ADDRESS;
         uint16_t nopCrcInput = static_cast<uint16_t>((1 << 14) | (nopAddr & 0x3FFF));
         uint8_t crcNOP = computeCRC8(nopCrcInput);
-        uint8_t txNOP[4] = {
-            padByte,
-            static_cast<uint8_t>(((nopAddr >> 8) & 0x3F) | 0x40),
-            static_cast<uint8_t>(nopAddr & 0xFF),
-            crcNOP
-        };
+        uint8_t txNOP[4] = {padByte, static_cast<uint8_t>(((nopAddr >> 8) & 0x3F) | 0x40),
+                            static_cast<uint8_t>(nopAddr & 0xFF), crcNOP};
         uint8_t rxDataFrame[4];
         spi.transfer(txNOP, rxDataFrame, 4);
-        
+
         // Process response with CRC verification
         uint16_t raw = (static_cast<uint16_t>(rxDataFrame[1]) << 8) | rxDataFrame[2];
         uint8_t crcDevice = rxDataFrame[3];
@@ -430,96 +439,88 @@ uint16_t AS5047U::readRegister(uint16_t address) const {
 
 bool AS5047U::writeRegister(uint16_t address, uint16_t value, uint8_t retries) const {
     bool success = false;
-    uint16_t errMask = static_cast<uint16_t>(AS5047U_Error::CrcError) | static_cast<uint16_t>(AS5047U_Error::FramingError);
+    uint16_t errMask = static_cast<uint16_t>(AS5047U_Error::CrcError) |
+                       static_cast<uint16_t>(AS5047U_Error::FramingError);
     for (uint8_t attempt = 0; attempt <= retries; ++attempt) {
         if (frameFormat == FrameFormat::SPI_16) {
             // ---- 16-bit write (two frames) ----
             // First frame: send address
-            uint16_t cmd = static_cast<uint16_t>(address & 0x3FFF);  // bit14=0 for write
-            uint8_t tx[2] = {
-                static_cast<uint8_t>(cmd >> 8),
-                static_cast<uint8_t>(cmd & 0xFF)
-            };
+            uint16_t cmd = static_cast<uint16_t>(address & 0x3FFF); // bit14=0 for write
+            uint8_t tx[2] = {static_cast<uint8_t>(cmd >> 8), static_cast<uint8_t>(cmd & 0xFF)};
             uint8_t rx_dummy[2];
             spi.transfer(tx, rx_dummy, 2);
-            
+
             // Second frame: send data payload
             uint16_t dataFrame = value & 0x3FFF;
             tx[0] = static_cast<uint8_t>(dataFrame >> 8);
             tx[1] = static_cast<uint8_t>(dataFrame & 0xFF);
             uint8_t rxDataResp[2];
             spi.transfer(tx, rxDataResp, 2);
-            
+
             // Check for errors from previous command
             auto err = readReg<AS5047U_REG::ERRFL>().value;
-            if (!(err & errMask)) { success = true; break; }
+            if (!(err & errMask)) {
+                success = true;
+                break;
+            }
             updateStickyErrors(err);
-        } 
-        else if (frameFormat == FrameFormat::SPI_24) {
+        } else if (frameFormat == FrameFormat::SPI_24) {
             // ---- 24-bit write with CRC ----
             // First frame: send address with CRC
             uint16_t cmdPayload = static_cast<uint16_t>((0 << 14) | (address & 0x3FFF));
             uint8_t cmdCrc = computeCRC8(cmdPayload);
             uint8_t txCmd[3] = {
-                static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x00),  // bit6=0 for write
-                static_cast<uint8_t>(address & 0xFF),
-                cmdCrc
-            };
+                static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x00), // bit6=0 for write
+                static_cast<uint8_t>(address & 0xFF), cmdCrc};
             uint8_t rxCmd[3];
             spi.transfer(txCmd, rxCmd, 3);
-            
+
             // Second frame: send data with CRC
             uint16_t dataPayload = value & 0x3FFF;
             uint8_t dataCrc = computeCRC8(dataPayload);
-            uint8_t txData[3] = {
-                static_cast<uint8_t>((dataPayload >> 8) & 0xFF),
-                static_cast<uint8_t>(dataPayload & 0xFF),
-                dataCrc
-            };
+            uint8_t txData[3] = {static_cast<uint8_t>((dataPayload >> 8) & 0xFF),
+                                 static_cast<uint8_t>(dataPayload & 0xFF), dataCrc};
             uint8_t rxData[3];
             spi.transfer(txData, rxData, 3);
-            
+
             // after write, check error flags
             auto err = readReg<AS5047U_REG::ERRFL>().value;
-            if (!(err & errMask)) { success = true; break; }
+            if (!(err & errMask)) {
+                success = true;
+                break;
+            }
             updateStickyErrors(err);
-        } 
-        else if (frameFormat == FrameFormat::SPI_32) {
+        } else if (frameFormat == FrameFormat::SPI_32) {
             // ---- 32-bit write with CRC and pad byte ----
             // First frame: send address with CRC and pad
             uint16_t cmdPayload = static_cast<uint16_t>((0 << 14) | (address & 0x3FFF));
             uint8_t cmdCrc = computeCRC8(cmdPayload);
             uint8_t txCmd[4] = {
                 padByte,
-                static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x00),  // bit6=0 for write
-                static_cast<uint8_t>(address & 0xFF),
-                cmdCrc
-            };
+                static_cast<uint8_t>(((address >> 8) & 0x3F) | 0x00), // bit6=0 for write
+                static_cast<uint8_t>(address & 0xFF), cmdCrc};
             uint8_t rxCmd[4];
             spi.transfer(txCmd, rxCmd, 4);
-            
+
             // Second frame: send data with CRC and pad
             uint16_t dataPayload = value & 0x3FFF;
             uint8_t dataCrc = computeCRC8(dataPayload);
-            uint8_t txData[4] = {
-                padByte,
-                static_cast<uint8_t>((dataPayload >> 8) & 0xFF),
-                static_cast<uint8_t>(dataPayload & 0xFF),
-                dataCrc
-            };
+            uint8_t txData[4] = {padByte, static_cast<uint8_t>((dataPayload >> 8) & 0xFF),
+                                 static_cast<uint8_t>(dataPayload & 0xFF), dataCrc};
             uint8_t rxData[4];
             spi.transfer(txData, rxData, 4);
-            
+
             // after write, check error flags
             auto err = readReg<AS5047U_REG::ERRFL>().value;
-            if (!(err & errMask)) { success = true; break; }
+            if (!(err & errMask)) {
+                success = true;
+                break;
+            }
             updateStickyErrors(err);
         }
     }
     return success;
 }
-
-
 
 // ════════════════════════════════════════════════════════════════════════════════════════════
 //                       Public API: retry-enabled getters and status dump
@@ -531,8 +532,8 @@ void AS5047U::dumpStatus() const {
     // Core measurements
     printf("Angle (COM) : %u\n", getAngle());
     printf("Angle (UNC) : %u\n", getRawAngle());
-    printf("Velocity    : %d counts (%.3f deg/s, %.3f rad/s, %.3f RPM)\n",
-           getVelocity(), getVelocityDegPerSec(), getVelocityRadPerSec(), getVelocityRPM());
+    printf("Velocity    : %d counts (%.3f deg/s, %.3f rad/s, %.3f RPM)\n", getVelocity(),
+           getVelocityDegPerSec(), getVelocityRadPerSec(), getVelocityRPM());
     printf("AGC         : %u\n", getAGC());
     printf("Magnitude   : %u\n", getMagnitude());
     // Error flags
@@ -554,26 +555,27 @@ void AS5047U::dumpStatus() const {
     printf("  SPI_cnt          : %u\n", dia.bits.SPI_cnt);
     // Configuration registers
     auto dis = readReg<AS5047U_REG::DISABLE>();
-    printf("DISABLE (0x0015): 0x%04X UVW_off=%u ABI_off=%u FILTER_disable=%u\n",
-           dis.value, dis.bits.UVW_off, dis.bits.ABI_off, dis.bits.FILTER_disable);
+    printf("DISABLE (0x0015): 0x%04X UVW_off=%u ABI_off=%u FILTER_disable=%u\n", dis.value,
+           dis.bits.UVW_off, dis.bits.ABI_off, dis.bits.FILTER_disable);
     auto s1 = readReg<AS5047U_REG::SETTINGS1>();
-    printf("SETTINGS1(0x0016): K_max=%u K_min=%u Dia3_en=%u Dia4_en=%u\n",
-           s1.bits.K_max, s1.bits.K_min, s1.bits.Dia3_en, s1.bits.Dia4_en);
+    printf("SETTINGS1(0x0016): K_max=%u K_min=%u Dia3_en=%u Dia4_en=%u\n", s1.bits.K_max,
+           s1.bits.K_min, s1.bits.Dia3_en, s1.bits.Dia4_en);
     auto s2 = readReg<AS5047U_REG::SETTINGS2>();
-    printf("SETTINGS2(0x0019): IWIDTH=%u NOISESET=%u DIR=%u UVW_ABI=%u DAECDIS=%u ABI_DEC=%u Data_select=%u PWMon=%u\n",
-           s2.bits.IWIDTH, s2.bits.NOISESET, s2.bits.DIR, s2.bits.UVW_ABI,
-           s2.bits.DAECDIS, s2.bits.ABI_DEC, s2.bits.Data_select, s2.bits.PWMon);
+    printf("SETTINGS2(0x0019): IWIDTH=%u NOISESET=%u DIR=%u UVW_ABI=%u DAECDIS=%u ABI_DEC=%u "
+           "Data_select=%u PWMon=%u\n",
+           s2.bits.IWIDTH, s2.bits.NOISESET, s2.bits.DIR, s2.bits.UVW_ABI, s2.bits.DAECDIS,
+           s2.bits.ABI_DEC, s2.bits.Data_select, s2.bits.PWMon);
     auto s3 = readReg<AS5047U_REG::SETTINGS3>();
-    printf("SETTINGS3(0x001A): UVWPP=%u HYS=%u ABIRES=%u\n",
-           s3.bits.UVWPP, s3.bits.HYS, s3.bits.ABIRES);
+    printf("SETTINGS3(0x001A): UVWPP=%u HYS=%u ABIRES=%u\n", s3.bits.UVWPP, s3.bits.HYS,
+           s3.bits.ABIRES);
     // Other registers
     auto sind = readReg<AS5047U_REG::SINDATA>();
     printf("SINDATA(0x3FFA): %d\n", sind.bits.SINDATA);
     auto eccsum = readReg<AS5047U_REG::ECC_Checksum>();
     printf("ECC_Checksum(0x3FD0): %u\n", eccsum.bits.ECC_s);
     auto prog = readReg<AS5047U_REG::PROG>();
-    printf("PROG(0x0003): PROGEN=%u PROGOTP=%u OTPREF=%u PROGVER=%u\n",
-           prog.bits.PROGEN, prog.bits.PROGOTP, prog.bits.OTPREF, prog.bits.PROGVER);
+    printf("PROG(0x0003): PROGEN=%u PROGOTP=%u OTPREF=%u PROGVER=%u\n", prog.bits.PROGEN,
+           prog.bits.PROGOTP, prog.bits.OTPREF, prog.bits.PROGVER);
     // Interface settings
     printf("FrameFormat      : %u  PadByte=0x%02X\n", static_cast<uint8_t>(frameFormat), padByte);
     printf("========================================\n\n");

--- a/src/AS5047U_REGISTERS.hpp
+++ b/src/AS5047U_REGISTERS.hpp
@@ -1,15 +1,16 @@
 /**
  * @file AS5047U_REGISTERS.hpp
  * @brief Register definitions for the AS5047U Rotary Position Sensor.
- * 
- * @details This file provides structured register definitions for the AS5047U magnetic position sensor,
- * including both volatile (runtime) registers and non-volatile (OTP) registers. Each register is defined
- * as a struct with its address, full register value access, and bit-field access through a union.
- * 
- * The AS5047U is a 14-bit on-axis magnetic rotary position sensor with incremental (ABI) and 
+ *
+ * @details This file provides structured register definitions for the AS5047U magnetic position
+ * sensor, including both volatile (runtime) registers and non-volatile (OTP) registers. Each
+ * register is defined as a struct with its address, full register value access, and bit-field
+ * access through a union.
+ *
+ * The AS5047U is a 14-bit on-axis magnetic rotary position sensor with incremental (ABI) and
  * commutation (UVW) interfaces. It features field-programmable OTP memory for custom configuration
  * and dynamic angle error compensation (DAEC).
- * 
+ *
  * Key features accessible through these registers:
  * - 14-bit absolute position measurement (0-16383 counts per revolution)
  * - Configurable incremental encoder output (ABI interface)
@@ -18,10 +19,10 @@
  * - Configurable PWM output
  * - Programmable zero position
  * - Error flags and diagnostics
- * 
- * The register definitions include both the raw register addresses and structured bit fields 
+ *
+ * The register definitions include both the raw register addresses and structured bit fields
  * for easier programmatic access.
- * 
+ *
  * @author Nebiyu Tadesse
  * @copyright Copyright (c) 2025 Nebiyu Tadesse
  * @license GNU GPL v3 or later
@@ -33,22 +34,22 @@
 namespace AS5047U_REG {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                                                                                                  //
-//   ██╗   ██╗ ██████╗ ██╗      █████╗ ████████╗██╗██╗     ███████╗                                                 //
-//   ██║   ██║██╔═══██╗██║     ██╔══██╗╚══██╔══╝██║██║     ██╔════╝                                                 //
-//   ██║   ██║██║   ██║██║     ███████║   ██║   ██║██║     █████╗                                                   //
-//   ╚██╗ ██╔╝██║   ██║██║     ██╔══██║   ██║   ██║██║     ██╔══╝                                                   //
-//    ╚████╔╝ ╚██████╔╝███████╗██║  ██║   ██║   ██║███████╗███████╗                                                 //
-//     ╚═══╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝╚══════╝                                                 //
+//   ██╗   ██╗ ██████╗ ██╗      █████╗ ████████╗██╗██╗     ███████╗ // ██║   ██║██╔═══██╗██║
+//   ██╔══██╗╚══██╔══╝██║██║     ██╔════╝                                                 // ██║
+//   ██║██║   ██║██║     ███████║   ██║   ██║██║     █████╗ // ╚██╗ ██╔╝██║   ██║██║     ██╔══██║
+//   ██║   ██║██║     ██╔══╝                                                   //
+//    ╚████╔╝ ╚██████╔╝███████╗██║  ██║   ██║   ██║███████╗███████╗ //
+//     ╚═══╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝╚══════╝ //
 //                                                                                                                  //
-//   ██████╗ ███████╗ ██████╗ ██╗███████╗████████╗███████╗██████╗ ███████╗                                          //
-//   ██╔══██╗██╔════╝██╔════╝ ██║██╔════╝╚══██╔══╝██╔════╝██╔══██╗██╔════╝                                          //
-//   ██████╔╝█████╗  ██║  ███╗██║███████╗   ██║   █████╗  ██████╔╝███████╗                                          //
-//   ██╔══██╗██╔══╝  ██║   ██║██║╚════██║   ██║   ██╔══╝  ██╔══██╗╚════██║                                          //
-//   ██║  ██║███████╗╚██████╔╝██║███████║   ██║   ███████╗██║  ██║███████║                                          //
-//   ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝╚══════╝   ╚═╝   ╚══════╝╚═╝  ╚═╝╚══════╝                                          //
+//   ██████╗ ███████╗ ██████╗ ██╗███████╗████████╗███████╗██████╗ ███████╗ //
+//   ██╔══██╗██╔════╝██╔════╝ ██║██╔════╝╚══██╔══╝██╔════╝██╔══██╗██╔════╝ // ██████╔╝█████╗  ██║
+//   ███╗██║███████╗   ██║   █████╗  ██████╔╝███████╗                                          //
+//   ██╔══██╗██╔══╝  ██║   ██║██║╚════██║   ██║   ██╔══╝  ██╔══██╗╚════██║ // ██║
+//   ██║███████╗╚██████╔╝██║███████║   ██║   ███████╗██║  ██║███████║ // ╚═╝  ╚═╝╚══════╝ ╚═════╝
+//   ╚═╝╚══════╝   ╚═╝   ╚══════╝╚═╝  ╚═╝╚══════╝                                          //
 //                                                                                                                  //
 //==================================================================================================================//
-//                                           VOLATILE REGISTERS                                                     //
+//                                           VOLATILE REGISTERS //
 //==================================================================================================================//
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -59,7 +60,8 @@ namespace AS5047U_REG {
  * ------- | ---- | ------- | -----------
  * 0x0000  | NOP  | 0x0000  | No operation
  *
- * @details The NOP register is used to perform a no-operation command. Reading or writing to this register has no effect.
+ * @details The NOP register is used to perform a no-operation command. Reading or writing to this
+ * register has no effect.
  */
 struct NOP {
     static constexpr uint16_t ADDRESS = 0x0000;
@@ -75,39 +77,43 @@ struct NOP {
  * @brief ERRFL – Error Flag register (0x0001, default 0x0000)
  *
  * Bits | Name                    | R  | Description
- * ---- | ----------------------- | -- | -------------------------------------------------------------------------------
- * 0    | AGC_warning             | R  | AGC at limit flag (1 = AGC value reached 0 or 255, indicating extreme magnetic field)
- * 1    | MagHalf                 | R  | Magnetic field half error (1 = AGC=255 and measured magnitude ~ half of target)
- * 2    | P2RAM_warning           | R  | OTP shadow (P2RAM) single-bit correction flag (ECC corrected one bit)
- * 3    | P2RAM_error             | R  | OTP shadow (P2RAM) double-bit error flag (uncorrectable ECC error)
- * 4    | Framing_error           | R  | SPI framing error (bad SPI frame alignment)
- * 5    | Command_error           | R  | SPI command error (invalid SPI command received)
- * 6    | CRC_error               | R  | SPI CRC communication error (CRC checksum mismatch)
- * 7    | WDTST                   | R  | Watchdog failure (1 = internal oscillator or watchdog test failed)
- * 8    | (unused)                | -  | Unused bit (always 0)
- * 9    | OffCompNotFinished      | R  | Offset compensation not finished (1 = internal offset calibration still in progress)
- * 10   | CORDIC_Overflow         | R  | CORDIC overflow error flag (numerical overflow in CORDIC cord. calc)
- * 11-15| (reserved)              | -  | Reserved (reads 0)
+ * ---- | ----------------------- | -- |
+ * ------------------------------------------------------------------------------- 0    |
+ * AGC_warning             | R  | AGC at limit flag (1 = AGC value reached 0 or 255, indicating
+ * extreme magnetic field) 1    | MagHalf                 | R  | Magnetic field half error (1 =
+ * AGC=255 and measured magnitude ~ half of target) 2    | P2RAM_warning           | R  | OTP shadow
+ * (P2RAM) single-bit correction flag (ECC corrected one bit) 3    | P2RAM_error             | R  |
+ * OTP shadow (P2RAM) double-bit error flag (uncorrectable ECC error) 4    | Framing_error | R  |
+ * SPI framing error (bad SPI frame alignment) 5    | Command_error           | R  | SPI command
+ * error (invalid SPI command received) 6    | CRC_error               | R  | SPI CRC communication
+ * error (CRC checksum mismatch) 7    | WDTST                   | R  | Watchdog failure (1 =
+ * internal oscillator or watchdog test failed) 8    | (unused)                | -  | Unused bit
+ * (always 0) 9    | OffCompNotFinished      | R  | Offset compensation not finished (1 = internal
+ * offset calibration still in progress) 10   | CORDIC_Overflow         | R  | CORDIC overflow error
+ * flag (numerical overflow in CORDIC cord. calc) 11-15| (reserved)              | -  | Reserved
+ * (reads 0)
  *
- * @note Reading the ERRFL register clears all the error flags (self-clearing on read). In case any error flag is set, it is recommended to read the DIA (Diagnostic) register for more detailed status.
+ * @note Reading the ERRFL register clears all the error flags (self-clearing on read). In case any
+ * error flag is set, it is recommended to read the DIA (Diagnostic) register for more detailed
+ * status.
  */
 struct ERRFL {
     static constexpr uint16_t ADDRESS = 0x0001;
     union {
         uint16_t value;
         struct {
-            uint16_t AGC_warning        : 1;
-            uint16_t MagHalf            : 1;
-            uint16_t P2RAM_warning      : 1;
-            uint16_t P2RAM_error        : 1;
-            uint16_t Framing_error      : 1;
-            uint16_t Command_error      : 1;
-            uint16_t CRC_error          : 1;
-            uint16_t WDTST              : 1;
-            uint16_t unused_8           : 1;
+            uint16_t AGC_warning : 1;
+            uint16_t MagHalf : 1;
+            uint16_t P2RAM_warning : 1;
+            uint16_t P2RAM_error : 1;
+            uint16_t Framing_error : 1;
+            uint16_t Command_error : 1;
+            uint16_t CRC_error : 1;
+            uint16_t WDTST : 1;
+            uint16_t unused_8 : 1;
             uint16_t OffCompNotFinished : 1;
-            uint16_t CORDIC_Overflow    : 1;
-            uint16_t reserved_11_15     : 5;
+            uint16_t CORDIC_Overflow : 1;
+            uint16_t reserved_11_15 : 5;
         } bits;
     };
 };
@@ -116,38 +122,43 @@ struct ERRFL {
  * @brief PROG – OTP programming control register (0x0003, default 0x0000)
  *
  * Bits | Name      | R/W | Description
- * ---- | --------- | --- | -------------------------------------------------------------------------
- * 0    | PROGEN    | R/W | OTP program enable (0 = Normal operation, 1 = Enable OTP read/write access)
- * 1    | (reserved)| -   | Reserved (must be 0)
- * 2    | OTPREF    | R/W | OTP refresh trigger (1 = refresh shadow registers with OTP content)
- * 3    | PROGOTP   | R/W | Start OTP programming cycle (set 1 to begin burning OTP fuses)
- * 4    | (reserved)| -   | Reserved (must be 0)
- * 5    | (reserved)| -   | Reserved (must be 0)
- * 6    | PROGVER   | R/W | Program verify mode enable (1 = enable guard-band verification mode)
- * 7-15 | (reserved)| -   | Reserved (must be 0)
+ * ---- | --------- | --- |
+ * ------------------------------------------------------------------------- 0    | PROGEN    | R/W
+ * | OTP program enable (0 = Normal operation, 1 = Enable OTP read/write access) 1    | (reserved)|
+ * -   | Reserved (must be 0) 2    | OTPREF    | R/W | OTP refresh trigger (1 = refresh shadow
+ * registers with OTP content) 3    | PROGOTP   | R/W | Start OTP programming cycle (set 1 to begin
+ * burning OTP fuses) 4    | (reserved)| -   | Reserved (must be 0) 5    | (reserved)| -   |
+ * Reserved (must be 0) 6    | PROGVER   | R/W | Program verify mode enable (1 = enable guard-band
+ * verification mode) 7-15 | (reserved)| -   | Reserved (must be 0)
  *
  * @details Writing this register controls the OTP programming sequence:
- * - Set **PROGEN=1** to enable OTP programming mode (allow OTP registers 0x0015–0x001B to be written).
- * - Then set **PROGOTP=1** to initiate the OTP burn procedure. The PROGOTP bit will self-clear when the programming cycle completes.
- * - The **PROGVER** bit can be set to 1 to enter verification mode (guard band test) after programming.
- * - Toggling **OTPREF** (e.g., set to 1) reloads the non-volatile data from OTP into the device's shadow registers (useful after programming or to revert soft writes).
+ * - Set **PROGEN=1** to enable OTP programming mode (allow OTP registers 0x0015–0x001B to be
+ * written).
+ * - Then set **PROGOTP=1** to initiate the OTP burn procedure. The PROGOTP bit will self-clear when
+ * the programming cycle completes.
+ * - The **PROGVER** bit can be set to 1 to enter verification mode (guard band test) after
+ * programming.
+ * - Toggling **OTPREF** (e.g., set to 1) reloads the non-volatile data from OTP into the device's
+ * shadow registers (useful after programming or to revert soft writes).
  *
- * After starting a programming cycle, the host should poll the PROG register until it reads 0x0001, indicating the procedure is complete (PROGEN remains set, other bits cleared). 
- * It is recommended to perform verification and a power cycle (with PROGVER and OTPREF as described in the datasheet) to ensure OTP programming success.
+ * After starting a programming cycle, the host should poll the PROG register until it reads 0x0001,
+ * indicating the procedure is complete (PROGEN remains set, other bits cleared). It is recommended
+ * to perform verification and a power cycle (with PROGVER and OTPREF as described in the datasheet)
+ * to ensure OTP programming success.
  */
 struct PROG {
     static constexpr uint16_t ADDRESS = 0x0003;
     union {
         uint16_t value;
         struct {
-            uint16_t PROGEN        : 1;
-            uint16_t reserved_1    : 1;
-            uint16_t OTPREF        : 1;
-            uint16_t PROGOTP       : 1;
-            uint16_t reserved_4    : 1;
-            uint16_t reserved_5    : 1;
-            uint16_t PROGVER       : 1;
-            uint16_t reserved_7    : 1;
+            uint16_t PROGEN : 1;
+            uint16_t reserved_1 : 1;
+            uint16_t OTPREF : 1;
+            uint16_t PROGOTP : 1;
+            uint16_t reserved_4 : 1;
+            uint16_t reserved_5 : 1;
+            uint16_t PROGVER : 1;
+            uint16_t reserved_7 : 1;
             uint16_t reserved_8_15 : 8;
         } bits;
     };
@@ -157,25 +168,31 @@ struct PROG {
  * @brief DIA – Diagnostic register (0x3FF5, read-only)
  *
  * Bits | Name               | R | Description
- * ---- | ------------------ | - | -------------------------------------------------------------------------------
- * 0    | VDD_mode           | R | Supply voltage mode (0 = 3.3V operation mode, 1 = 5V operation mode)
- * 1    | LoopsFinished      | R | Magneto-mechanical loops finished (1 = all internal startup loops complete)
- * 2    | CORDIC_overflow_flag | R | CORDIC overflow error flag (1 = CORDIC arithmetic overflow occurred)
+ * ---- | ------------------ | - |
+ * ------------------------------------------------------------------------------- 0    | VDD_mode
+ * | R | Supply voltage mode (0 = 3.3V operation mode, 1 = 5V operation mode) 1    | LoopsFinished
+ * | R | Magneto-mechanical loops finished (1 = all internal startup loops complete) 2    |
+ * CORDIC_overflow_flag | R | CORDIC overflow error flag (1 = CORDIC arithmetic overflow occurred)
  * 3    | Comp_l             | R | AGC low *warning* flag (1 = magnetic field *strong* – AGC near 0)
- * 4    | Comp_h             | R | AGC high *warning* flag (1 = magnetic field *weak* – AGC near 255)
- * 5    | MagHalf_flag       | R | Magnitude half-range error flag (1 = measured MAG below half of target)
- * 6    | CosOff_fin         | R | Cosine offset compensation finished (1 = cosine offset calib complete)
- * 7    | SinOff_fin         | R | Sine offset compensation finished (1 = sine offset calib complete)
- * 8    | OffComp_finished   | R | Offset compensation finished flag (0 = still running, 1 = completed)
- * 9    | AGC_finished       | R | AGC initialization finished (1 = initial gain calibration complete)
- * 10   | (unused)           | - | Unused bit (always 0)
- * 11-12| SPI_cnt            | R | SPI frame counter (2-bit rolling count of consecutive SPI frames)
- * 13-15| (reserved)         | - | Reserved (reads 0)
+ * 4    | Comp_h             | R | AGC high *warning* flag (1 = magnetic field *weak* – AGC near
+ * 255) 5    | MagHalf_flag       | R | Magnitude half-range error flag (1 = measured MAG below half
+ * of target) 6    | CosOff_fin         | R | Cosine offset compensation finished (1 = cosine offset
+ * calib complete) 7    | SinOff_fin         | R | Sine offset compensation finished (1 = sine
+ * offset calib complete) 8    | OffComp_finished   | R | Offset compensation finished flag (0 =
+ * still running, 1 = completed) 9    | AGC_finished       | R | AGC initialization finished (1 =
+ * initial gain calibration complete) 10   | (unused)           | - | Unused bit (always 0) 11-12|
+ * SPI_cnt            | R | SPI frame counter (2-bit rolling count of consecutive SPI frames) 13-15|
+ * (reserved)         | - | Reserved (reads 0)
  *
- * @details The DIA register provides detailed status and diagnostic flags. Many of these flags correspond to whether internal calibration processes have completed or whether certain conditions are at warning levels. 
- * For example, **AGC_finished** indicates the automatic gain control initial settling is done, and **OffComp_finished** indicates the zero-angle offset compensation routine is done. 
- * **Comp_h** and **Comp_l** are warning flags showing the AGC is at the high or low end (magnet too weak or strong), while **MagHalf_flag** mirrors the MagHalf error (magnetic field half) status. 
- * The 2-bit **SPI_cnt** increments with each SPI frame, which can help detect communication synchronization issues. 
+ * @details The DIA register provides detailed status and diagnostic flags. Many of these flags
+ * correspond to whether internal calibration processes have completed or whether certain conditions
+ * are at warning levels. For example, **AGC_finished** indicates the automatic gain control initial
+ * settling is done, and **OffComp_finished** indicates the zero-angle offset compensation routine
+ * is done.
+ * **Comp_h** and **Comp_l** are warning flags showing the AGC is at the high or low end (magnet too
+ * weak or strong), while **MagHalf_flag** mirrors the MagHalf error (magnetic field half) status.
+ * The 2-bit **SPI_cnt** increments with each SPI frame, which can help detect communication
+ * synchronization issues.
  * **VDD_mode** simply reflects the detected supply range (3.3V vs 5V) of the device.
  */
 struct DIA {
@@ -183,19 +200,19 @@ struct DIA {
     union {
         uint16_t value;
         struct {
-            uint16_t VDD_mode         : 1;
-            uint16_t LoopsFinished    : 1;
+            uint16_t VDD_mode : 1;
+            uint16_t LoopsFinished : 1;
             uint16_t CORDIC_overflow_flag : 1;
-            uint16_t Comp_l           : 1;
-            uint16_t Comp_h           : 1;
-            uint16_t MagHalf_flag     : 1;
-            uint16_t CosOff_fin       : 1;
-            uint16_t SinOff_fin       : 1;
+            uint16_t Comp_l : 1;
+            uint16_t Comp_h : 1;
+            uint16_t MagHalf_flag : 1;
+            uint16_t CosOff_fin : 1;
+            uint16_t SinOff_fin : 1;
             uint16_t OffComp_finished : 1;
-            uint16_t AGC_finished     : 1;
-            uint16_t unused_10        : 1;
-            uint16_t SPI_cnt          : 2;
-            uint16_t reserved_13_15   : 3;
+            uint16_t AGC_finished : 1;
+            uint16_t unused_10 : 1;
+            uint16_t SPI_cnt : 2;
+            uint16_t reserved_13_15 : 3;
         } bits;
     };
 };
@@ -205,19 +222,20 @@ struct DIA {
  *
  * Bits | Name       | R | Description
  * ---- | ---------- | - | -----------------------------------------------
- * 0-7  | AGC_value  | R | 8-bit AGC value (dynamic gain level, 0x00=minimum gain, 0xFF=maximum gain)
- * 8-15 | (reserved) | - | Reserved (reads 0)
+ * 0-7  | AGC_value  | R | 8-bit AGC value (dynamic gain level, 0x00=minimum gain, 0xFF=maximum
+ * gain) 8-15 | (reserved) | - | Reserved (reads 0)
  *
- * @details The AGC_value represents the current automatic gain control setting of the sensor’s analog front-end. 
- * A low value (near 0) means the magnetic field is strong (gain reduced), whereas a high value (near 255) means the field is weak (gain increased). 
- * This value is continuously adjusted to keep the CORDIC magnitude stable.
+ * @details The AGC_value represents the current automatic gain control setting of the sensor’s
+ * analog front-end. A low value (near 0) means the magnetic field is strong (gain reduced), whereas
+ * a high value (near 255) means the field is weak (gain increased). This value is continuously
+ * adjusted to keep the CORDIC magnitude stable.
  */
 struct AGC {
     static constexpr uint16_t ADDRESS = 0x3FF9;
     union {
         uint16_t value;
         struct {
-            uint16_t AGC_value     : 8;
+            uint16_t AGC_value : 8;
             uint16_t reserved_8_15 : 8;
         } bits;
     };
@@ -230,7 +248,8 @@ struct AGC {
  * ---- | -------- | - | ---------------------------------------------
  * 0-15 | SINDATA  | R | Raw digital sine channel data (16-bit signed)
  *
- * @details The SINDATA register provides the raw digital output of the sine channel from the sensor’s CORDIC engine. The value is a signed 16-bit integer.
+ * @details The SINDATA register provides the raw digital output of the sine channel from the
+ * sensor’s CORDIC engine. The value is a signed 16-bit integer.
  */
 struct SINDATA {
     static constexpr uint16_t ADDRESS = 0x3FFA;
@@ -249,7 +268,8 @@ struct SINDATA {
  * ---- | -------- | - | ---------------------------------------------
  * 0-15 | COSDATA  | R | Raw digital cosine channel data (16-bit signed)
  *
- * @details The COSDATA register provides the raw digital output of the cosine channel from the sensor’s CORDIC engine. The value is a signed 16-bit integer.
+ * @details The COSDATA register provides the raw digital output of the cosine channel from the
+ * sensor’s CORDIC engine. The value is a signed 16-bit integer.
  */
 struct COSDATA {
     static constexpr uint16_t ADDRESS = 0x3FFB;
@@ -269,17 +289,19 @@ struct COSDATA {
  * 0-13 | VEL_value  | R | Measured velocity (14-bit two’s complement value)
  * 14-15| (reserved) | - | Reserved bits (reads 0)
  *
- * @details VEL_value is a signed 14-bit integer representing the rotational velocity. The value is given in two’s complement format. 
- * A positive value indicates rotation in the default direction (DIR=0 defined direction), while a negative value indicates rotation in the opposite direction. 
- * The scale (LSB unit) is proportional to speed, but the exact units depend on the sensor configuration and sampling rate (e.g., LSB per measurement interval).
+ * @details VEL_value is a signed 14-bit integer representing the rotational velocity. The value is
+ * given in two’s complement format. A positive value indicates rotation in the default direction
+ * (DIR=0 defined direction), while a negative value indicates rotation in the opposite direction.
+ * The scale (LSB unit) is proportional to speed, but the exact units depend on the sensor
+ * configuration and sampling rate (e.g., LSB per measurement interval).
  */
 struct VEL {
     static constexpr uint16_t ADDRESS = 0x3FFC;
     union {
         uint16_t value;
         struct {
-            uint16_t VEL_value     : 14;
-            uint16_t reserved_14_15: 2;
+            uint16_t VEL_value : 14;
+            uint16_t reserved_14_15 : 2;
         } bits;
     };
 };
@@ -292,16 +314,19 @@ struct VEL {
  * 0-13 | MAG_value  | R | CORDIC magnitude (14-bit value of magnetic field strength)
  * 14-15| (reserved) | - | Reserved bits (reads 0)
  *
- * @details The MAG_value represents the magnitude of the vector computed by the CORDIC (Coordinate Rotation Digital Computer), corresponding to the strength of the magnetic field as seen by the sensor. 
- * Under normal conditions with a properly placed magnet, this value stays near a target level (e.g., ~0x0FFF). A significantly lower value (together with the MagHalf_flag in DIA or MagHalf in ERRFL) indicates the field is about half of the expected strength.
+ * @details The MAG_value represents the magnitude of the vector computed by the CORDIC (Coordinate
+ * Rotation Digital Computer), corresponding to the strength of the magnetic field as seen by the
+ * sensor. Under normal conditions with a properly placed magnet, this value stays near a target
+ * level (e.g., ~0x0FFF). A significantly lower value (together with the MagHalf_flag in DIA or
+ * MagHalf in ERRFL) indicates the field is about half of the expected strength.
  */
 struct MAG {
     static constexpr uint16_t ADDRESS = 0x3FFD;
     union {
         uint16_t value;
         struct {
-            uint16_t MAG_value     : 14;
-            uint16_t reserved_14_15: 2;
+            uint16_t MAG_value : 14;
+            uint16_t reserved_14_15 : 2;
         } bits;
     };
 };
@@ -314,17 +339,18 @@ struct MAG {
  * 0-13 | ANGLEUNC_value| R | Absolute angle without dynamic compensation (14-bit)
  * 14-15| (reserved)    | - | Reserved bits (reads 0)
  *
- * @details ANGLEUNC_value is the raw angle measurement from the Hall sensor array and CORDIC, not including the Dynamic Angle Error Compensation (DAEC) filtering. 
- * The value is 14-bit (0–16383) representing 0–360° (with 0x0000 corresponding to 0° and 0x3FFF (~16383) corresponding to just shy of 360°). 
- * Use this register if the dynamically compensated angle (ANGLECOM) is not desired.
+ * @details ANGLEUNC_value is the raw angle measurement from the Hall sensor array and CORDIC, not
+ * including the Dynamic Angle Error Compensation (DAEC) filtering. The value is 14-bit (0–16383)
+ * representing 0–360° (with 0x0000 corresponding to 0° and 0x3FFF (~16383) corresponding to just
+ * shy of 360°). Use this register if the dynamically compensated angle (ANGLECOM) is not desired.
  */
 struct ANGLEUNC {
     static constexpr uint16_t ADDRESS = 0x3FFE;
     union {
         uint16_t value;
         struct {
-            uint16_t ANGLEUNC_value: 14;
-            uint16_t reserved_14_15: 2;
+            uint16_t ANGLEUNC_value : 14;
+            uint16_t reserved_14_15 : 2;
         } bits;
     };
 };
@@ -336,14 +362,15 @@ struct ANGLEUNC {
  * ---- | ------ | --- | -------------------------------------------------------------------------
  * 6:0  | ECC_s  | R   | Calculated ECC checksum based on actual register setting
  *
- * @details The ECC_Checksum register provides a 7-bit ECC checksum value calculated based on the current register settings.
+ * @details The ECC_Checksum register provides a 7-bit ECC checksum value calculated based on the
+ * current register settings.
  */
 struct ECC_Checksum {
     static constexpr uint16_t ADDRESS = 0x3FD0;
     union {
         uint16_t value;
         struct {
-            uint16_t ECC_s         : 7; // Calculated ECC checksum
+            uint16_t ECC_s : 7;         // Calculated ECC checksum
             uint16_t reserved_7_15 : 9; // Reserved bits
         } bits;
     };
@@ -357,40 +384,45 @@ struct ECC_Checksum {
  * 0-13 | ANGLECOM_value| R | Absolute angle with dynamic compensation (14-bit)
  * 14-15| (reserved)    | - | Reserved bits (reads 0)
  *
- * @details ANGLECOM_value is the fully compensated 14-bit absolute angle reading, incorporating the sensor’s dynamic angle error compensation (DAEC) algorithm. 
- * This value is updated in real-time with minimal latency at high speeds, thanks to DAEC. It is the primary angle output for most applications. 
- * If the Data_select bit in SETTINGS2 is 0 (default), reading from address 0x3FFF returns this ANGLECOM value. 
- * The angle is represented as a number from 0 to 16383 corresponding to 0° to 360° (with 14-bit resolution).
+ * @details ANGLECOM_value is the fully compensated 14-bit absolute angle reading, incorporating the
+ * sensor’s dynamic angle error compensation (DAEC) algorithm. This value is updated in real-time
+ * with minimal latency at high speeds, thanks to DAEC. It is the primary angle output for most
+ * applications. If the Data_select bit in SETTINGS2 is 0 (default), reading from address 0x3FFF
+ * returns this ANGLECOM value. The angle is represented as a number from 0 to 16383 corresponding
+ * to 0° to 360° (with 14-bit resolution).
  */
 struct ANGLECOM {
     static constexpr uint16_t ADDRESS = 0x3FFF;
     union {
         uint16_t value;
         struct {
-            uint16_t ANGLECOM_value: 14;
-            uint16_t reserved_14_15: 2;
+            uint16_t ANGLECOM_value : 14;
+            uint16_t reserved_14_15 : 2;
         } bits;
     };
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                                                                                                  //
-//   ███╗   ██╗ ██████╗ ███╗   ██╗      ██╗   ██╗ ██████╗ ██╗      █████╗ ████████╗██╗██╗     ███████╗              //
-//   ████╗  ██║██╔═══██╗████╗  ██║      ██║   ██║██╔═══██╗██║     ██╔══██╗╚══██╔══╝██║██║     ██╔════╝              //
-//   ██╔██╗ ██║██║   ██║██╔██╗ ██║      ██║   ██║██║   ██║██║     ███████║   ██║   ██║██║     █████╗                //
-//   ██║╚██╗██║██║   ██║██║╚██╗██║      ╚██╗ ██╔╝██║   ██║██║     ██╔══██║   ██║   ██║██║     ██╔══╝                //
-//   ██║ ╚████║╚██████╔╝██║ ╚████║       ╚████╔╝ ╚██████╔╝███████╗██║  ██║   ██║   ██║███████╗███████╗              //
-//   ╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═══╝        ╚═══╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝╚══════╝              //
+//   ███╗   ██╗ ██████╗ ███╗   ██╗      ██╗   ██╗ ██████╗ ██╗      █████╗ ████████╗██╗██╗ ███████╗
+//   // ████╗  ██║██╔═══██╗████╗  ██║      ██║   ██║██╔═══██╗██║     ██╔══██╗╚══██╔══╝██║██║
+//   ██╔════╝              // ██╔██╗ ██║██║   ██║██╔██╗ ██║      ██║   ██║██║   ██║██║     ███████║
+//   ██║   ██║██║     █████╗                // ██║╚██╗██║██║   ██║██║╚██╗██║      ╚██╗ ██╔╝██║
+//   ██║██║     ██╔══██║   ██║   ██║██║     ██╔══╝                // ██║ ╚████║╚██████╔╝██║ ╚████║
+//   ╚████╔╝ ╚██████╔╝███████╗██║  ██║   ██║   ██║███████╗███████╗              // ╚═╝  ╚═══╝
+//   ╚═════╝ ╚═╝  ╚═══╝        ╚═══╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝╚══════╝ //
 //                                                                                                                  //
-//   ██████╗ ███████╗ ██████╗ ██╗███████╗████████╗███████╗██████╗ ███████╗    ██╗ ██████╗ ████████╗██████╗ ██╗      //
-//   ██╔══██╗██╔════╝██╔════╝ ██║██╔════╝╚══██╔══╝██╔════╝██╔══██╗██╔════╝    ██║██╔═══██╗╚══██╔══╝██╔══██╗██║      //
-//   ██████╔╝█████╗  ██║  ███╗██║███████╗   ██║   █████╗  ██████╔╝███████╗    ██║██║   ██║   ██║   ██████╔╝██║      //
-//   ██╔══██╗██╔══╝  ██║   ██║██║╚════██║   ██║   ██╔══╝  ██╔══██╗╚════██║    ╚═╝██║   ██║   ██║   ██╔═══╝ ╚═╝      //
-//   ██║  ██║███████╗╚██████╔╝██║███████║   ██║   ███████╗██║  ██║███████║    ██╗╚██████╔╝   ██║   ██║     ██╗      //
-//   ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝╚══════╝   ╚═╝   ╚══════╝╚═╝  ╚═╝╚══════╝    ╚═╝ ╚═════╝    ╚═╝   ╚═╝     ╚═╝      //
+//   ██████╗ ███████╗ ██████╗ ██╗███████╗████████╗███████╗██████╗ ███████╗    ██╗ ██████╗
+//   ████████╗██████╗ ██╗      // ██╔══██╗██╔════╝██╔════╝
+//   ██║██╔════╝╚══██╔══╝██╔════╝██╔══██╗██╔════╝    ██║██╔═══██╗╚══██╔══╝██╔══██╗██║      //
+//   ██████╔╝█████╗  ██║  ███╗██║███████╗   ██║   █████╗  ██████╔╝███████╗    ██║██║   ██║   ██║
+//   ██████╔╝██║      // ██╔══██╗██╔══╝  ██║   ██║██║╚════██║   ██║   ██╔══╝  ██╔══██╗╚════██║
+//   ╚═╝██║   ██║   ██║   ██╔═══╝ ╚═╝      // ██║  ██║███████╗╚██████╔╝██║███████║   ██║ ███████╗██║
+//   ██║███████║    ██╗╚██████╔╝   ██║   ██║     ██╗      // ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝╚══════╝
+//   ╚═╝   ╚══════╝╚═╝  ╚═╝╚══════╝    ╚═╝ ╚═════╝    ╚═╝   ╚═╝     ╚═╝      //
 //                                                                                                                  //
 //==================================================================================================================//
-//                                      NON-VOLATILE REGISTERS (OTP)                                                //
+//                                      NON-VOLATILE REGISTERS (OTP) //
 //==================================================================================================================//
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -402,40 +434,40 @@ struct ANGLECOM {
  * 0    | UVW_off       | R/W/P | UVW outputs off (0 = Normal mode, 1 = UVW pins tristate)
  * 1    | ABI_off       | R/W/P | ABI outputs off (0 = Normal mode, 1 = ABI pins tristate)
  * 2-5  | (reserved)    | R/W/P | Reserved bits (must be 0)
- * 6    | FILTER_disable| R/W/P | Disable output filter (0 = Filter enabled (default), 1 = Filter disabled)
- * 7    | (reserved)    | R/W/P | Reserved bit (must be 0)
- * 8-15 | (unused)      | -     | Unused upper bits (reads 0)
+ * 6    | FILTER_disable| R/W/P | Disable output filter (0 = Filter enabled (default), 1 = Filter
+ * disabled) 7    | (reserved)    | R/W/P | Reserved bit (must be 0) 8-15 | (unused)      | -     |
+ * Unused upper bits (reads 0)
  */
 struct DISABLE {
     static constexpr uint16_t ADDRESS = 0x0015;
     union {
         uint16_t value;
         struct {
-            uint16_t UVW_off       : 1;
-            uint16_t ABI_off       : 1;
-            uint16_t reserved_2_5  : 4;
-            uint16_t FILTER_disable: 1;
-            uint16_t reserved_7    : 1;
+            uint16_t UVW_off : 1;
+            uint16_t ABI_off : 1;
+            uint16_t reserved_2_5 : 4;
+            uint16_t FILTER_disable : 1;
+            uint16_t reserved_7 : 1;
             uint16_t reserved_8_15 : 8;
         } bits;
     };
-    
+
     /// @brief UVW output mode (UVW_off bit)
     enum class UVWMode : uint8_t {
-        Normal = 0,    /**< Normal operation mode (UVW outputs active) */
-        Tristate = 1   /**< High-impedance mode (UVW pins tristated) */
+        Normal = 0,  /**< Normal operation mode (UVW outputs active) */
+        Tristate = 1 /**< High-impedance mode (UVW pins tristated) */
     };
-    
+
     /// @brief ABI output mode (ABI_off bit)
     enum class ABIMode : uint8_t {
-        Normal = 0,    /**< Normal operation mode (ABI outputs active) */
-        Tristate = 1   /**< High-impedance mode (ABI pins tristated) */
+        Normal = 0,  /**< Normal operation mode (ABI outputs active) */
+        Tristate = 1 /**< High-impedance mode (ABI pins tristated) */
     };
-    
+
     /// @brief Output filter control (FILTER_disable bit)
     enum class FilterMode : uint8_t {
-        Enabled = 0,   /**< Digital filter enabled (default) */
-        Disabled = 1   /**< Digital filter disabled (faster response, more noise) */
+        Enabled = 0, /**< Digital filter enabled (default) */
+        Disabled = 1 /**< Digital filter disabled (faster response, more noise) */
     };
 };
 
@@ -454,8 +486,8 @@ struct ZPOSM {
     union {
         uint16_t value;
         struct {
-            uint16_t ZPOSM_bits   : 8;
-            uint16_t reserved_8_15: 8;
+            uint16_t ZPOSM_bits : 8;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
 };
@@ -464,11 +496,12 @@ struct ZPOSM {
  * @brief ZPOSL – Zero Position LSB register (0x0017, default 0x0000)
  *
  * Bits | Name    | R/W/P | Description
- * ---- | ------- | ----- | -------------------------------------------------------------------------
- * 0-5  | ZPOSL   | R/W/P | Least significant 6 bits of the zero position
- * 6    | Dia1_en | R/W/P | Diagnostic feature 1 (Default 0; for AS5147U automotive variant only)
- * 7    | Dia2_en | R/W/P | Diagnostic feature 2 (Default 0; for AS5147U automotive variant only)
- * 8-15 | (unused)| -     | Unused upper bits (reads 0)
+ * ---- | ------- | ----- |
+ * ------------------------------------------------------------------------- 0-5  | ZPOSL   | R/W/P
+ * | Least significant 6 bits of the zero position 6    | Dia1_en | R/W/P | Diagnostic feature 1
+ * (Default 0; for AS5147U automotive variant only) 7    | Dia2_en | R/W/P | Diagnostic feature 2
+ * (Default 0; for AS5147U automotive variant only) 8-15 | (unused)| -     | Unused upper bits
+ * (reads 0)
  *
  * @note Bits 6 and 7 are not applicable on the AS5047U (remain 0 unless using AS5147U).
  */
@@ -477,10 +510,10 @@ struct ZPOSL {
     union {
         uint16_t value;
         struct {
-            uint16_t ZPOSL_bits   : 6;
-            uint16_t Dia1_en      : 1;
-            uint16_t Dia2_en      : 1;
-            uint16_t reserved_8_15: 8;
+            uint16_t ZPOSL_bits : 6;
+            uint16_t Dia1_en : 1;
+            uint16_t Dia2_en : 1;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
 };
@@ -496,22 +529,23 @@ struct ZPOSL {
  * 7    | Dia4_en | R/W/P | Diagnostic feature 4 (Default 0; not applicable for AS5047U)
  * 8-15 | (unused)| -     | Unused upper bits (reads 0)
  *
- * @details K_max and K_min define the adaptive filter's dynamic range. Higher K values increase filter bandwidth (more noise, less filtering). 
- *          Both default to 0 (minimum filter setting). Dia3_en and Dia4_en are reserved (used only in the AS5147U variant).
+ * @details K_max and K_min define the adaptive filter's dynamic range. Higher K values increase
+ * filter bandwidth (more noise, less filtering). Both default to 0 (minimum filter setting).
+ * Dia3_en and Dia4_en are reserved (used only in the AS5147U variant).
  */
 struct SETTINGS1 {
     static constexpr uint16_t ADDRESS = 0x0018;
     union {
         uint16_t value;
         struct {
-            uint16_t K_max        : 3;
-            uint16_t K_min        : 3;
-            uint16_t Dia3_en      : 1;
-            uint16_t Dia4_en      : 1;
-            uint16_t reserved_8_15: 8;
+            uint16_t K_max : 3;
+            uint16_t K_min : 3;
+            uint16_t Dia3_en : 1;
+            uint16_t Dia4_en : 1;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
-    /// @brief Enumerated options for K_max field (adaptive filter max coefficient) 
+    /// @brief Enumerated options for K_max field (adaptive filter max coefficient)
     enum class AdaptiveFilterKmax : uint8_t {
         Code0 = 0b000, /**< K_max actual value = 6 (default) */
         Code1 = 0b001, /**< K_max actual value = 5 */
@@ -539,38 +573,41 @@ struct SETTINGS1 {
  * @brief SETTINGS2 – Custom setting register 2 (0x0019, default 0x0000)
  *
  * Bits | Name       | R/W/P | Description
- * ---- | ---------- | ----- | -------------------------------------------------------------------------------
- * 0    | IWIDTH     | R/W/P | Index pulse width (0: 3 LSB pulses (default), 1: 1 LSB pulse)
- * 1    | NOISESET   | R/W/P | Noise setting for 3.3V operation at 150°C (0: Normal noise, 1: Reduced noise)
- * 2    | DIR        | R/W/P | Rotation direction setting (0: CW default, 1: Invert direction)
- * 3    | UVW_ABI    | R/W/P | Select ABI or UVW interface for outputs and PWM (0: ABI active, PWM on W; 1: UVW active, PWM on I)
- * 4    | DAECDIS    | R/W/P | Dynamic angle error compensation disable (0: DAEC on (default), 1: DAEC off)
- * 5    | ABI_DEC    | R/W/P | ABI decimal count enable (0: Binary resolution, 1: Decimal pulses per revolution)
- * 6    | Data_select| R/W/P | Selects angle data at 0x3FFF (0: ANGLECOM, 1: ANGLEUNC readout)
- * 7    | PWMon      | R/W/P | PWM output enable (0: PWM disabled, 1: PWM enabled)
+ * ---- | ---------- | ----- |
+ * ------------------------------------------------------------------------------- 0    | IWIDTH |
+ * R/W/P | Index pulse width (0: 3 LSB pulses (default), 1: 1 LSB pulse) 1    | NOISESET   | R/W/P |
+ * Noise setting for 3.3V operation at 150°C (0: Normal noise, 1: Reduced noise) 2    | DIR        |
+ * R/W/P | Rotation direction setting (0: CW default, 1: Invert direction) 3    | UVW_ABI    | R/W/P
+ * | Select ABI or UVW interface for outputs and PWM (0: ABI active, PWM on W; 1: UVW active, PWM on
+ * I) 4    | DAECDIS    | R/W/P | Dynamic angle error compensation disable (0: DAEC on (default), 1:
+ * DAEC off) 5    | ABI_DEC    | R/W/P | ABI decimal count enable (0: Binary resolution, 1: Decimal
+ * pulses per revolution) 6    | Data_select| R/W/P | Selects angle data at 0x3FFF (0: ANGLECOM, 1:
+ * ANGLEUNC readout) 7    | PWMon      | R/W/P | PWM output enable (0: PWM disabled, 1: PWM enabled)
  * 8-15 | (unused)   | -     | Unused upper bits (reads 0)
  *
- * @details This register configures various interface options. IWIDTH sets the index pulse width in the ABI interface. 
- *          DIR inverts the direction of the incremental signals (defines rotation direction as clockwise when DIR=0). 
- *          UVW_ABI selects which incremental interface is active and which pin outputs the PWM signal. 
- *          Setting DAECDIS=1 disables dynamic angle error compensation (the angle outputs will be raw). 
- *          ABI_DEC=1 selects a decimal pulse count per revolution (e.g., 1000 ppr) instead of binary powers of two. 
- *          Data_select controls whether the 0x3FFF address returns the compensated or uncompensated angle. PWM output must be enabled (PWMon=1) and mapped via UVW_ABI.
+ * @details This register configures various interface options. IWIDTH sets the index pulse width in
+ * the ABI interface. DIR inverts the direction of the incremental signals (defines rotation
+ * direction as clockwise when DIR=0). UVW_ABI selects which incremental interface is active and
+ * which pin outputs the PWM signal. Setting DAECDIS=1 disables dynamic angle error compensation
+ * (the angle outputs will be raw). ABI_DEC=1 selects a decimal pulse count per revolution (e.g.,
+ * 1000 ppr) instead of binary powers of two. Data_select controls whether the 0x3FFF address
+ * returns the compensated or uncompensated angle. PWM output must be enabled (PWMon=1) and mapped
+ * via UVW_ABI.
  */
 struct SETTINGS2 {
     static constexpr uint16_t ADDRESS = 0x0019;
     union {
         uint16_t value;
         struct {
-            uint16_t IWIDTH      : 1;
-            uint16_t NOISESET    : 1;
-            uint16_t DIR         : 1;
-            uint16_t UVW_ABI     : 1;
-            uint16_t DAECDIS     : 1;
-            uint16_t ABI_DEC     : 1;
+            uint16_t IWIDTH : 1;
+            uint16_t NOISESET : 1;
+            uint16_t DIR : 1;
+            uint16_t UVW_ABI : 1;
+            uint16_t DAECDIS : 1;
+            uint16_t ABI_DEC : 1;
             uint16_t Data_select : 1;
-            uint16_t PWMon       : 1;
-            uint16_t reserved_8_15: 8;
+            uint16_t PWMon : 1;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
     /// @brief Index pulse width options (IWIDTH bit)
@@ -580,13 +617,13 @@ struct SETTINGS2 {
     };
     /// @brief High-temperature noise reduction setting (NOISESET bit)
     enum class NoiseSetting : uint8_t {
-        Normal = 0,     /**< Normal noise setting (for typical conditions) */
-        HighTemp = 1    /**< Reduced noise for 3.3V operation at ~150°C (use at high temp) */
+        Normal = 0,  /**< Normal noise setting (for typical conditions) */
+        HighTemp = 1 /**< Reduced noise for 3.3V operation at ~150°C (use at high temp) */
     };
     /// @brief Rotation direction setting (DIR bit) – defines incremental output phase sense
     enum class RotationDirection : uint8_t {
-        Normal = 0,    /**< Default rotation direction (CW defined as DIR=0) */
-        Inverted = 1   /**< Inverted rotation direction (swap A/B phasing) */
+        Normal = 0,  /**< Default rotation direction (CW defined as DIR=0) */
+        Inverted = 1 /**< Inverted rotation direction (swap A/B phasing) */
     };
     /// @brief Output interface selection for ABI vs UVW and PWM mapping (UVW_ABI bit)
     enum class OutputInterfaceMode : uint8_t {
@@ -595,13 +632,13 @@ struct SETTINGS2 {
     };
     /// @brief Dynamic angle error compensation (DAEC) mode (DAECDIS bit)
     enum class DynamicCompensation : uint8_t {
-        Enabled = 0,  /**< DAEC enabled (dynamic compensation ON, default) */
-        Disabled = 1  /**< DAEC disabled (output raw angle without comp.) */
+        Enabled = 0, /**< DAEC enabled (dynamic compensation ON, default) */
+        Disabled = 1 /**< DAEC disabled (output raw angle without comp.) */
     };
     /// @brief ABI resolution counting mode (ABI_DEC bit) – binary vs decimal pulses per revolution
     enum class ABICountMode : uint8_t {
-        Binary   = 0, /**< Binary resolution (2^N steps per revolution) */
-        Decimal  = 1  /**< Decimal resolution (e.g., 1000 pulses per revolution if configured) */
+        Binary = 0, /**< Binary resolution (2^N steps per revolution) */
+        Decimal = 1 /**< Decimal resolution (e.g., 1000 pulses per revolution if configured) */
     };
     /// @brief Angle data source for 0x3FFF output (Data_select bit)
     enum class AngleOutputSource : uint8_t {
@@ -611,7 +648,7 @@ struct SETTINGS2 {
     /// @brief PWM output enable (PWMon bit)
     enum class PWMMode : uint8_t {
         Disabled = 0, /**< PWM output disabled */
-        Enabled  = 1  /**< PWM output enabled */
+        Enabled = 1   /**< PWM output enabled */
     };
 };
 
@@ -633,47 +670,53 @@ static_assert(sizeof(SETTINGS2) == 2, "SETTINGS2 must be 2 bytes");
  * - 10: 3 LSB hysteresis (0.52°)
  * - 11: 0 LSB (no hysteresis, outputs may toggle on slightest motion)
  *
- * The ABIRES field selects the incremental encoder resolution. Its interpretation depends on ABI_DEC (binary or decimal mode). 
- * For binary mode (ABI_DEC=0): code 0b000 = 12-bit (4096 steps/1024 pulses per rev, default), 0b001 = 11-bit, 0b010 = 10-bit, 0b011 = 13-bit, 0b100 = 14-bit (16384 steps/4096 ppr, max). 
- * Codes 0b101–0b111 are reserved in binary mode (treated as 14-bit max).
- * For decimal mode (ABI_DEC=1): codes map to decimal pulses: 0b000 = 1000 ppr (4000 steps), 0b001 = 500 ppr, 0b010 = 400 ppr, 0b011 = 300 ppr, 0b100 = 200 ppr, 0b101 = 100 ppr, 0b110 = 50 ppr, 0b111 = 25 ppr.
+ * The ABIRES field selects the incremental encoder resolution. Its interpretation depends on
+ * ABI_DEC (binary or decimal mode). For binary mode (ABI_DEC=0): code 0b000 = 12-bit (4096
+ * steps/1024 pulses per rev, default), 0b001 = 11-bit, 0b010 = 10-bit, 0b011 = 13-bit, 0b100 =
+ * 14-bit (16384 steps/4096 ppr, max). Codes 0b101–0b111 are reserved in binary mode (treated as
+ * 14-bit max). For decimal mode (ABI_DEC=1): codes map to decimal pulses: 0b000 = 1000 ppr (4000
+ * steps), 0b001 = 500 ppr, 0b010 = 400 ppr, 0b011 = 300 ppr, 0b100 = 200 ppr, 0b101 = 100 ppr,
+ * 0b110 = 50 ppr, 0b111 = 25 ppr.
  */
 struct SETTINGS3 {
     static constexpr uint16_t ADDRESS = 0x001A;
     union {
         uint16_t value;
         struct {
-            uint16_t UVWPP       : 3;
-            uint16_t HYS         : 2;
-            uint16_t ABIRES      : 3;
-            uint16_t reserved_8_15: 8;
+            uint16_t UVWPP : 3;
+            uint16_t HYS : 2;
+            uint16_t ABIRES : 3;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
     /// @brief UVW pole pair count (UVWPP) options for BLDC commutation
     enum class UVWPolePairs : uint8_t {
-        PP1     = 0b000, /**< 1 pole pair (default) */
-        PP2     = 0b001, /**< 2 pole pairs */
-        PP3     = 0b010, /**< 3 pole pairs */
-        PP4     = 0b011, /**< 4 pole pairs */
-        PP5     = 0b100, /**< 5 pole pairs */
-        PP6     = 0b101, /**< 6 pole pairs */
-        PP7     = 0b110, /**< 7 pole pairs (also for code 0b111) */
-        PP7_ALT = 0b111  /**< 7 pole pairs (alternate code, same as 0b110) */
+        PP1 = 0b000,    /**< 1 pole pair (default) */
+        PP2 = 0b001,    /**< 2 pole pairs */
+        PP3 = 0b010,    /**< 3 pole pairs */
+        PP4 = 0b011,    /**< 4 pole pairs */
+        PP5 = 0b100,    /**< 5 pole pairs */
+        PP6 = 0b101,    /**< 6 pole pairs */
+        PP7 = 0b110,    /**< 7 pole pairs (also for code 0b111) */
+        PP7_ALT = 0b111 /**< 7 pole pairs (alternate code, same as 0b110) */
     };
     /// @brief Incremental output hysteresis (HYS) settings:
     enum class Hysteresis : uint8_t {
         LSB_1 = 0b00, /**< 1 LSB hysteresis (default, ~0.17°) */
         LSB_2 = 0b01, /**< 2 LSB hysteresis (~0.35°) */
         LSB_3 = 0b10, /**< 3 LSB hysteresis (~0.52°) */
-        NONE  = 0b11  /**< 0 LSB hysteresis (no hysteresis) */
+        NONE = 0b11   /**< 0 LSB hysteresis (no hysteresis) */
     };
-    /// @brief ABI interface resolution (ABIRES) codes – see description for binary vs decimal mode interpretation
+    /// @brief ABI interface resolution (ABIRES) codes – see description for binary vs decimal mode
+    /// interpretation
     enum class ABIResolution : uint8_t {
-        Code0 = 0b000, /**< Binary: 4096 steps (1024 ppr, 12-bit) ; Decimal: 4000 steps (1000 ppr) */
+        Code0 =
+            0b000, /**< Binary: 4096 steps (1024 ppr, 12-bit) ; Decimal: 4000 steps (1000 ppr) */
         Code1 = 0b001, /**< Binary: 2048 steps (512 ppr, 11-bit) ; Decimal: 2000 steps (500 ppr) */
         Code2 = 0b010, /**< Binary: 1024 steps (256 ppr, 10-bit) ; Decimal: 1600 steps (400 ppr) */
         Code3 = 0b011, /**< Binary: 8192 steps (2048 ppr, 13-bit) ; Decimal: 1200 steps (300 ppr) */
-        Code4 = 0b100, /**< Binary: 16384 steps (4096 ppr, 14-bit) ; Decimal: 800 steps  (200 ppr) */
+        Code4 =
+            0b100, /**< Binary: 16384 steps (4096 ppr, 14-bit) ; Decimal: 800 steps  (200 ppr) */
         Code5 = 0b101, /**< (Reserved in binary mode)            ; Decimal: 400 steps (100 ppr) */
         Code6 = 0b110, /**< (Reserved in binary mode)            ; Decimal: 200 steps (50 ppr) */
         Code7 = 0b111  /**< (Reserved in binary mode)            ; Decimal: 100 steps (25 ppr) */
@@ -691,24 +734,26 @@ static_assert(sizeof(SETTINGS3) == 2, "SETTINGS3 must be 2 bytes");
  * 7    | ECC_en     | R/W/P | Enable ECC protection (0 = disable, 1 = enable ECC)
  * 8-15 | (unused)   | -     | Unused upper bits (reads 0)
  *
- * @details This register holds the Error-Correcting Code (ECC) for the OTP registers. To protect the custom settings, set ECC_en=1 and then program the ECC_chsum with the correct checksum before burning OTP. 
- * The 7-bit ECC checksum must be computed (read from address 0x00D1/ECC_s mirror after enabling ECC) and written here prior to final OTP programming.
+ * @details This register holds the Error-Correcting Code (ECC) for the OTP registers. To protect
+ * the custom settings, set ECC_en=1 and then program the ECC_chsum with the correct checksum before
+ * burning OTP. The 7-bit ECC checksum must be computed (read from address 0x00D1/ECC_s mirror after
+ * enabling ECC) and written here prior to final OTP programming.
  */
 struct ECC {
     static constexpr uint16_t ADDRESS = 0x001B;
     union {
         uint16_t value;
         struct {
-            uint16_t ECC_chsum    : 7;
-            uint16_t ECC_en       : 1;
-            uint16_t reserved_8_15: 8;
+            uint16_t ECC_chsum : 7;
+            uint16_t ECC_en : 1;
+            uint16_t reserved_8_15 : 8;
         } bits;
     };
-    
+
     /// @brief ECC enable/disable (ECC_en bit)
     enum class ECCMode : uint8_t {
         Disabled = 0, /**< ECC disabled (default) */
-        Enabled  = 1  /**< ECC enabled (protects OTP content) */
+        Enabled = 1   /**< ECC enabled (protects OTP content) */
     };
 };
 


### PR DESCRIPTION
## Summary
- add ESP-IDF example project with dummy bus
- register driver as hf_as5047u ESP-IDF component
- update CI workflow to build ESP-IDF example
- format sources using clang-format
