### PR TITLE
Documentation link errors

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -15,7 +15,7 @@ Complete reference documentation for all public methods and types in the AS5047U
 
 - **Main Header**: [`inc/as5047u.hpp`](../inc/as5047u.hpp)
 - **SPI Interface**: [`inc/as5047u_spi_interface.hpp`](../inc/as5047u_spi_interface.hpp)
-- **Implementation**: [`src/as5047u.cpp`](../src/as5047u.cpp)
+- **Implementation**: [`src/as5047u.ipp`](../src/as5047u.ipp)
 - **Registers**: [`inc/as5047u_registers.hpp`](../inc/as5047u_registers.hpp)
 
 ## Core Class
@@ -41,66 +41,66 @@ explicit AS5047U(SpiType& bus, FrameFormat format = AS5047U_CFG::DEFAULT_FRAME_F
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `SetFrameFormat()` | `void SetFrameFormat(FrameFormat format) noexcept` | [`src/as5047u.cpp#L16`](../src/as5047u.cpp#L16) |
+| `SetFrameFormat()` | `void SetFrameFormat(FrameFormat format) noexcept` | [`src/as5047u.ipp#L16`](../src/as5047u.ipp#L16) |
 
 ### Angle Reading
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `GetAngle()` | `uint16_t GetAngle(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L33`](../src/as5047u.cpp#L33) |
-| `GetRawAngle()` | `uint16_t GetRawAngle(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L48`](../src/as5047u.cpp#L48) |
+| `GetAngle()` | `uint16_t GetAngle(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L33`](../src/as5047u.ipp#L33) |
+| `GetRawAngle()` | `uint16_t GetRawAngle(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L48`](../src/as5047u.ipp#L48) |
 
 ### Velocity Reading
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `GetVelocity()` | `int16_t GetVelocity(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L63`](../src/as5047u.cpp#L63) |
-| `GetVelocityDegPerSec()` | `float GetVelocityDegPerSec(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L79`](../src/as5047u.cpp#L79) |
-| `GetVelocityRadPerSec()` | `float GetVelocityRadPerSec(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L84`](../src/as5047u.cpp#L84) |
-| `GetVelocityRPM()` | `float GetVelocityRPM(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L89`](../src/as5047u.cpp#L89) |
+| `GetVelocity()` | `int16_t GetVelocity(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L63`](../src/as5047u.ipp#L63) |
+| `GetVelocityDegPerSec()` | `float GetVelocityDegPerSec(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L79`](../src/as5047u.ipp#L79) |
+| `GetVelocityRadPerSec()` | `float GetVelocityRadPerSec(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L84`](../src/as5047u.ipp#L84) |
+| `GetVelocityRPM()` | `float GetVelocityRPM(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L89`](../src/as5047u.ipp#L89) |
 
 ### Diagnostics
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `GetAGC()` | `uint8_t GetAGC(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L94`](../src/as5047u.cpp#L94) |
-| `GetMagnitude()` | `uint16_t GetMagnitude(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L109`](../src/as5047u.cpp#L109) |
-| `GetErrorFlags()` | `uint16_t GetErrorFlags(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L124`](../src/as5047u.cpp#L124) |
+| `GetAGC()` | `uint8_t GetAGC(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L94`](../src/as5047u.ipp#L94) |
+| `GetMagnitude()` | `uint16_t GetMagnitude(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L109`](../src/as5047u.ipp#L109) |
+| `GetErrorFlags()` | `uint16_t GetErrorFlags(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L124`](../src/as5047u.ipp#L124) |
 | `GetStickyErrorFlags()` | `AS5047U_Error GetStickyErrorFlags() const` | [`inc/as5047u.hpp#L384`](../inc/as5047u.hpp#L384) |
-| `DumpStatus()` | `void DumpStatus() const` | [`src/as5047u.cpp#L597`](../src/as5047u.cpp#L597) |
-| `GetDiagnostics()` | `AS5047U_REG::DIA GetDiagnostics() const` | [`src/as5047u.cpp#L393`](../src/as5047u.cpp#L393) |
+| `DumpStatus()` | `void DumpStatus() const` | [`src/as5047u.ipp#L597`](../src/as5047u.ipp#L597) |
+| `GetDiagnostics()` | `AS5047U_REG::DIA GetDiagnostics() const` | [`src/as5047u.ipp#L393`](../src/as5047u.ipp#L393) |
 
 ### Configuration
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `GetZeroPosition()` | `uint16_t GetZeroPosition(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.cpp#L135`](../src/as5047u.cpp#L135) |
-| `SetZeroPosition()` | `bool SetZeroPosition(uint16_t angle_lsb, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L162`](../src/as5047u.cpp#L162) |
+| `GetZeroPosition()` | `uint16_t GetZeroPosition(uint8_t retries = AS5047U_CFG::CRC_RETRIES) const` | [`src/as5047u.ipp#L135`](../src/as5047u.ipp#L135) |
+| `SetZeroPosition()` | `bool SetZeroPosition(uint16_t angle_lsb, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L162`](../src/as5047u.ipp#L162) |
 | `SetDirection()` | `bool SetDirection(bool clockwise, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`inc/as5047u.hpp#L214`](../inc/as5047u.hpp#L214) |
-| `SetABIResolution()` | `bool SetABIResolution(uint8_t resolution_bits, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L171`](../src/as5047u.cpp#L171) |
-| `SetUVWPolePairs()` | `bool SetUVWPolePairs(uint8_t pairs, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L179`](../src/as5047u.cpp#L179) |
-| `SetIndexPulseLength()` | `bool SetIndexPulseLength(uint8_t lsb_len, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L187`](../src/as5047u.cpp#L187) |
-| `ConfigureInterface()` | `bool ConfigureInterface(bool abi, bool uvw, bool pwm, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L205`](../src/as5047u.cpp#L205) |
-| `SetDynamicAngleCompensation()` | `bool SetDynamicAngleCompensation(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L225`](../src/as5047u.cpp#L225) |
-| `SetAdaptiveFilter()` | `bool SetAdaptiveFilter(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L232`](../src/as5047u.cpp#L232) |
-| `SetFilterParameters()` | `bool SetFilterParameters(uint8_t k_min, uint8_t k_max, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L239`](../src/as5047u.cpp#L239) |
-| `Set150CTemperatureMode()` | `bool Set150CTemperatureMode(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L250`](../src/as5047u.cpp#L250) |
-| `SetHysteresis()` | `bool SetHysteresis(AS5047U_REG::SETTINGS3::Hysteresis hysteresis, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L315`](../src/as5047u.cpp#L315) |
-| `GetHysteresis()` | `AS5047U_REG::SETTINGS3::Hysteresis GetHysteresis() const` | [`src/as5047u.cpp#L322`](../src/as5047u.cpp#L322) |
-| `SetAngleOutputSource()` | `bool SetAngleOutputSource(AS5047U_REG::SETTINGS2::AngleOutputSource source, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.cpp#L333`](../src/as5047u.cpp#L333) |
-| `GetAngleOutputSource()` | `AS5047U_REG::SETTINGS2::AngleOutputSource GetAngleOutputSource() const` | [`src/as5047u.cpp#L340`](../src/as5047u.cpp#L340) |
+| `SetABIResolution()` | `bool SetABIResolution(uint8_t resolution_bits, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L171`](../src/as5047u.ipp#L171) |
+| `SetUVWPolePairs()` | `bool SetUVWPolePairs(uint8_t pairs, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L179`](../src/as5047u.ipp#L179) |
+| `SetIndexPulseLength()` | `bool SetIndexPulseLength(uint8_t lsb_len, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L187`](../src/as5047u.ipp#L187) |
+| `ConfigureInterface()` | `bool ConfigureInterface(bool abi, bool uvw, bool pwm, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L205`](../src/as5047u.ipp#L205) |
+| `SetDynamicAngleCompensation()` | `bool SetDynamicAngleCompensation(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L225`](../src/as5047u.ipp#L225) |
+| `SetAdaptiveFilter()` | `bool SetAdaptiveFilter(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L232`](../src/as5047u.ipp#L232) |
+| `SetFilterParameters()` | `bool SetFilterParameters(uint8_t k_min, uint8_t k_max, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L239`](../src/as5047u.ipp#L239) |
+| `Set150CTemperatureMode()` | `bool Set150CTemperatureMode(bool enable, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L250`](../src/as5047u.ipp#L250) |
+| `SetHysteresis()` | `bool SetHysteresis(AS5047U_REG::SETTINGS3::Hysteresis hysteresis, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L315`](../src/as5047u.ipp#L315) |
+| `GetHysteresis()` | `AS5047U_REG::SETTINGS3::Hysteresis GetHysteresis() const` | [`src/as5047u.ipp#L322`](../src/as5047u.ipp#L322) |
+| `SetAngleOutputSource()` | `bool SetAngleOutputSource(AS5047U_REG::SETTINGS2::AngleOutputSource source, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`src/as5047u.ipp#L333`](../src/as5047u.ipp#L333) |
+| `GetAngleOutputSource()` | `AS5047U_REG::SETTINGS2::AngleOutputSource GetAngleOutputSource() const` | [`src/as5047u.ipp#L340`](../src/as5047u.ipp#L340) |
 
 ### OTP Programming
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `ProgramOTP()` | `bool ProgramOTP()` | [`src/as5047u.cpp#L257`](../src/as5047u.cpp#L257) |
+| `ProgramOTP()` | `bool ProgramOTP()` | [`src/as5047u.ipp#L257`](../src/as5047u.ipp#L257) |
 
 ### Utility
 
 | Method | Signature | Location |
 |--------|-----------|----------|
-| `SetPad()` | `void SetPad(uint8_t pad) noexcept` | [`src/as5047u.cpp#L302`](../src/as5047u.cpp#L302) |
+| `SetPad()` | `void SetPad(uint8_t pad) noexcept` | [`src/as5047u.ipp#L302`](../src/as5047u.ipp#L302) |
 | `ComputeCRC8()` | `static constexpr uint8_t ComputeCRC8(uint16_t data16)` | [`inc/as5047u.hpp#L96`](../inc/as5047u.hpp#L96) |
 | `ReadReg()` | `template<typename RegT> RegT ReadReg() const` | [`inc/as5047u.hpp#L360`](../inc/as5047u.hpp#L360) |
 | `WriteReg()` | `template<typename RegT> bool WriteReg(const RegT& reg, uint8_t retries = AS5047U_CFG::CRC_RETRIES)` | [`inc/as5047u.hpp#L376`](../inc/as5047u.hpp#L376) |


### PR DESCRIPTION
Fix broken API reference links in `docs/api_reference.md` to resolve Lychee CI failures.

The `docs/api_reference.md` file contained links pointing to `src/as5047u.cpp`, but the corresponding source file was renamed to `src/as5047u.ipp`. This caused the Lychee link checker in CI to report "Cannot find file" errors for all these links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates; no runtime or build logic changes.
> 
> **Overview**
> Updates `docs/api_reference.md` to point the “Implementation” source and all method-location links from `src/as5047u.cpp` to `src/as5047u.ipp`, fixing broken internal references in the API docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f6275d57fcf0d1dd59731b10a09a851bd03f24e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->